### PR TITLE
fix: https://ipfs.fyi/helia-wg link update

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -39,7 +39,7 @@
 /kubo           https://github.com/ipfs/kubo 301
 /iroh           https://github.com/n0-computer/iroh 301
 
-/helia-wg https://pl-strflt.notion.site/Helia-Working-Group-WG-70bbeced695249808940bf7a37992f71 301
+/helia-wg https://foregoing-plantain-cf9.notion.site/Helia-Working-Group-WG-de0086343c944ed497567a0dba961754 301
 /helia-demo https://youtube.com/playlist?list=PLuhRWgmPaHtQAnt8INOe5-kV9TLVaUJ9v 301
 
 /dapps-wg https://github.com/ipfs/dapps-wg 301


### PR DESCRIPTION
Interplanetary Shipyard Notion now contains the Helia WG notion pages.